### PR TITLE
Fix iOS height/flex bug

### DIFF
--- a/site/src/components/header.js
+++ b/site/src/components/header.js
@@ -101,6 +101,7 @@ const Wrapper = styled.div`
   align-items: center;
   justify-content: space-between;
   padding: 20px 0;
+  flex: 1 0 auto;
 
   @media only screen and (max-width: 800px) {
     flex-direction: column;

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -173,6 +173,7 @@ const MainWrapper = styled.div`
   border-radius: 3px;
   background-color: #fff;
   margin-bottom: 100px;
+  flex: 1 0 auto;
 
   @media only screen and (max-width: 600px) {
     flex-direction: column;


### PR DESCRIPTION
Issue on iOS devices where header and main-wrapper would collapse because iOS implements flex in a crappy way.