### PR TITLE
Remove webgl background temporarily

### DIFF
--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -93,13 +93,12 @@ const Layout = ({ children }) => {
 
   return (
     <>
-      <CanvasBackground>
+      {/*<CanvasBackground>
         <Canvas camera={{ position: [0, 0, 15] }}>
-          {/* <fog attach="fog" args={[COLORS.pink, 1, 60]} /> */}
           <fog attach="fog" args={[COLORS.codGray, 5, 30]} />
           <Grid />
         </Canvas>
-      </CanvasBackground>
+      </CanvasBackground>*/}
       <Wrapper>
         <GlobalStyle />
         <Header siteTitle="Trevlig mjukvara" />


### PR DESCRIPTION
There seems to be an issue on Linux machines where the WebGL driver/something is blocked for some reason. Will investigate more - this is a quick and dirty fix for now.