### PR TITLE
Change default app name

### DIFF
--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -18,8 +18,8 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `gatsby-starter-default`,
-        short_name: `starter`,
+        name: `Trevlig Mjukvara`,
+        short_name: `Trevlig Mjukvara`,
         start_url: `/`,
         background_color: `#000`,
         theme_color: `#000`,


### PR DESCRIPTION
Changed two fields, one (long one) name seen in the "app switcher" and one short_name seen on the home screen.