### PR TITLE
Media session api

### DIFF
--- a/site/src/components/player.js
+++ b/site/src/components/player.js
@@ -43,9 +43,20 @@ const Player = ({ src, title }) => {
       audioPlayer.current.pause() 
     })
 
-    window.navigator.mediaSession.setActionHandler("seekto", details => {
-      audioPlayer.current.currentTime = details.seekTime
-    })
+    window.navigator.mediaSession.setActionHandler("seekforward", () => {
+      audioPlayer.current.currentTime += 15
+    })    
+
+    window.navigator.mediaSession.setActionHandler("seekbackward", () => {
+      audioPlayer.current.currentTime -= 15
+    })    
+
+    // NOTE: seekto is buggy for some reason. possible to seek but progress bar jumps around. 
+    // Same problem on youtube for example, so chances are there's no easy fix.
+    // Maybe look at setPositionState: https://developer.mozilla.org/en-US/docs/Web/API/MediaSession/setPositionState
+    // window.navigator.mediaSession.setActionHandler("seekto", details => {
+    //   audioPlayer.current.currentTime = details.seekTime
+    // })
   }
 
 

--- a/site/src/components/player.js
+++ b/site/src/components/player.js
@@ -18,29 +18,31 @@ const Player = ({ src, title }) => {
   const [activeEpisode] = useGlobalState("activeEpisode")
 
 
-  if ('mediaSession' in navigator) {
-    navigator.mediaSession.metadata = new window.MediaMetadata({
-      title: title,
-      artist: 'Trevlig Mjukvara',
-      album: 'Veckopodden om trevlig och otrevlig mjukvara',
-      artwork: [
-        {
-          src: logo,
-          sizes: '100x100', // HeightxWidth
-          type: 'image/png'
-        }
-      ]
+  if(typeof window !== 'undefined') {
+    if ('mediaSession' in window.navigator) {
+      window.navigator.mediaSession.metadata = new window.MediaMetadata({
+        title: title,
+        artist: 'Trevlig Mjukvara',
+        album: 'Veckopodden om trevlig och otrevlig mjukvara',
+        artwork: [
+          {
+            src: logo,
+            sizes: '100x100', // HeightxWidth
+            type: 'image/png'
+          }
+        ]
+      });
+    }
+
+
+    window.navigator.mediaSession.setActionHandler("play", () => {
+      audioPlayer.play();
+    });
+
+    window.navigator.mediaSession.setActionHandler("seekto", details => {
+      audioPlayer.currentTime = details.seekTime;
     });
   }
-
-
-  navigator.mediaSession.setActionHandler("play", () => {
-    audioPlayer.play();
-  });
-
-  navigator.mediaSession.setActionHandler("seekto", details => {
-    audioPlayer.currentTime = details.seekTime;
-  });
 
 
   const timeUpdate = () => {

--- a/site/src/components/player.js
+++ b/site/src/components/player.js
@@ -17,6 +17,32 @@ const Player = ({ src, title }) => {
   const progressBar = createRef()
   const [activeEpisode] = useGlobalState("activeEpisode")
 
+
+  if ('mediaSession' in navigator) {
+    navigator.mediaSession.metadata = new window.MediaMetadata({
+      title: title,
+      artist: 'Trevlig Mjukvara',
+      album: 'Veckopodden om trevlig och otrevlig mjukvara',
+      artwork: [
+        {
+          src: logo,
+          sizes: '100x100', // HeightxWidth
+          type: 'image/png'
+        }
+      ]
+    });
+  }
+
+
+  navigator.mediaSession.setActionHandler("play", () => {
+    audioPlayer.play();
+  });
+
+  navigator.mediaSession.setActionHandler("seekto", details => {
+    audioPlayer.currentTime = details.seekTime;
+  });
+
+
   const timeUpdate = () => {
     setCurrentTime(audioPlayer.current.currentTime)
     setDuration(audioPlayer.current.duration)

--- a/site/src/components/player.js
+++ b/site/src/components/player.js
@@ -36,12 +36,16 @@ const Player = ({ src, title }) => {
 
 
     window.navigator.mediaSession.setActionHandler("play", () => {
-      audioPlayer.play();
-    });
+      audioPlayer.current.play() 
+    })
+
+    window.navigator.mediaSession.setActionHandler("pause", () => {
+      audioPlayer.current.pause() 
+    })
 
     window.navigator.mediaSession.setActionHandler("seekto", details => {
-      audioPlayer.currentTime = details.seekTime;
-    });
+      audioPlayer.current.currentTime = details.seekTime
+    })
   }
 
 
@@ -62,7 +66,6 @@ const Player = ({ src, title }) => {
     const newTime =
       (e.nativeEvent.offsetX / progressBar.current.offsetWidth) * duration
     audioPlayer.current.currentTime = newTime
-    console.log(audioPlayer.current)
     setCurrentTime(newTime)
   }
 

--- a/site/src/components/player.js
+++ b/site/src/components/player.js
@@ -27,36 +27,36 @@ const Player = ({ src, title }) => {
         artwork: [
           {
             src: logo,
-            sizes: '100x100', // HeightxWidth
+            sizes: '100x100', 
             type: 'image/png'
           }
         ]
       });
+
+
+      window.navigator.mediaSession.setActionHandler("play", () => {
+        audioPlayer.current.play() 
+      })
+
+      window.navigator.mediaSession.setActionHandler("pause", () => {
+        audioPlayer.current.pause() 
+      })
+
+      window.navigator.mediaSession.setActionHandler("seekforward", () => {
+        audioPlayer.current.currentTime += 15
+      })    
+
+      window.navigator.mediaSession.setActionHandler("seekbackward", () => {
+        audioPlayer.current.currentTime -= 15
+      })    
+
+      // NOTE: seekto is buggy for some reason. possible to seek but progress bar jumps around. 
+      // Same problem on youtube for example, so chances are there's no easy fix.
+      // Maybe look at setPositionState: https://developer.mozilla.org/en-US/docs/Web/API/MediaSession/setPositionState
+      // window.navigator.mediaSession.setActionHandler("seekto", details => {
+      //   audioPlayer.current.currentTime = details.seekTime
+      // })
     }
-
-
-    window.navigator.mediaSession.setActionHandler("play", () => {
-      audioPlayer.current.play() 
-    })
-
-    window.navigator.mediaSession.setActionHandler("pause", () => {
-      audioPlayer.current.pause() 
-    })
-
-    window.navigator.mediaSession.setActionHandler("seekforward", () => {
-      audioPlayer.current.currentTime += 15
-    })    
-
-    window.navigator.mediaSession.setActionHandler("seekbackward", () => {
-      audioPlayer.current.currentTime -= 15
-    })    
-
-    // NOTE: seekto is buggy for some reason. possible to seek but progress bar jumps around. 
-    // Same problem on youtube for example, so chances are there's no easy fix.
-    // Maybe look at setPositionState: https://developer.mozilla.org/en-US/docs/Web/API/MediaSession/setPositionState
-    // window.navigator.mediaSession.setActionHandler("seekto", details => {
-    //   audioPlayer.current.currentTime = details.seekTime
-    // })
   }
 
 


### PR DESCRIPTION
Implementation of MediaSession API to enable playback controls in notifications field on mobile devices and better integration with apps which integrates with the MediaSession API (playback controls on Windows, Linux, macOS etc.)

Firefox on mobile seems to have worse support for this than Chrome. Still works, but less features.

Test here: https://deploy-preview-77--unruffled-mcclintock-c59034.netlify.app/

<img src="https://user-images.githubusercontent.com/22306228/104478925-23a60a80-55c3-11eb-8682-39a5acfde1d6.jpg" width="200" /><img src="https://user-images.githubusercontent.com/22306228/104478929-24d73780-55c3-11eb-909d-93647f75c416.jpg" width="200" />
