### PR TITLE
Change mastodon link to fikaverse

### DIFF
--- a/site/src/episodes/s01e01-s02e01.mdx
+++ b/site/src/episodes/s01e01-s02e01.mdx
@@ -119,7 +119,7 @@ Vi pratar om utmaningar som kommer.
 
 - Hemsida: https://trevligmjukvara.se
 - Mail: kontakt@trevligmjukvara.se
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
 

--- a/site/src/episodes/s02e02.mdx
+++ b/site/src/episodes/s02e02.mdx
@@ -55,7 +55,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 
 - Hemsida: https://trevligmjukvara.se
 - Mail: kontakt@trevligmjukvara.se
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
 

--- a/site/src/episodes/s02e03.mdx
+++ b/site/src/episodes/s02e03.mdx
@@ -47,7 +47,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 
 - Hemsida: https://trevligmjukvara.se
 - Mail: kontakt@trevligmjukvara.se
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
 

--- a/site/src/episodes/s02e04.mdx
+++ b/site/src/episodes/s02e04.mdx
@@ -40,7 +40,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 
 ## Feedback
 
-- @rgggn på twitter saknar oss i fediversumet och tipsar om fikaverse.club
+- @rgggn på twitter saknar oss i fediversumet och tipsar om mastodon.linuxkompis.se
 
 ## Kontakta oss
 

--- a/site/src/episodes/s02e04.mdx
+++ b/site/src/episodes/s02e04.mdx
@@ -40,13 +40,13 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 
 ## Feedback
 
-- @rgggn på twitter saknar oss i fediversumet och tipsar om mastodon.linuxkompis.se
+- @rgggn på twitter saknar oss i fediversumet och tipsar om fikaverse.club
 
 ## Kontakta oss
 
 - Hemsida: https://trevligmjukvara.se
 - Mail: kontakt@trevligmjukvara.se
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
 

--- a/site/src/episodes/s02e05.mdx
+++ b/site/src/episodes/s02e05.mdx
@@ -56,7 +56,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 
 ## Tack till
 

--- a/site/src/episodes/s02e06.mdx
+++ b/site/src/episodes/s02e06.mdx
@@ -51,7 +51,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 
 ## Tack till
 

--- a/site/src/episodes/s02e07.mdx
+++ b/site/src/episodes/s02e07.mdx
@@ -47,7 +47,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 
 ## Tack till
 

--- a/site/src/episodes/s02e08.mdx
+++ b/site/src/episodes/s02e08.mdx
@@ -59,7 +59,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s02e09.mdx
+++ b/site/src/episodes/s02e09.mdx
@@ -53,7 +53,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s02e10.mdx
+++ b/site/src/episodes/s02e10.mdx
@@ -60,7 +60,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s02e11.mdx
+++ b/site/src/episodes/s02e11.mdx
@@ -56,7 +56,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s02e12.mdx
+++ b/site/src/episodes/s02e12.mdx
@@ -46,7 +46,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s03e01.mdx
+++ b/site/src/episodes/s03e01.mdx
@@ -37,7 +37,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s03e02.mdx
+++ b/site/src/episodes/s03e02.mdx
@@ -37,7 +37,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s03e03.mdx
+++ b/site/src/episodes/s03e03.mdx
@@ -46,7 +46,7 @@ audioSourcePath: "https://aphid.fireside.fm/d/1437767933/e86366d5-e25c-4aab-9a13
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s03e04.mdx
+++ b/site/src/episodes/s03e04.mdx
@@ -39,7 +39,7 @@ Seb:
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s03e05.mdx
+++ b/site/src/episodes/s03e05.mdx
@@ -36,7 +36,7 @@ Pop!\_OS och Fedora i nya upplagor. SteamVR dissar macOS. Xiaomi i blåsväder, 
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s03e06.mdx
+++ b/site/src/episodes/s03e06.mdx
@@ -47,7 +47,7 @@ I veckans avsnitt bjuder vi på mycket Trevligheter. Firefox släpper ny version
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s03e07.mdx
+++ b/site/src/episodes/s03e07.mdx
@@ -44,7 +44,7 @@ Pine64 går på högvarv igen. Google tar bort en av våra favoritappar från Pl
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s03e08.mdx
+++ b/site/src/episodes/s03e08.mdx
@@ -40,7 +40,7 @@ Vi chockas av EA. Patenttroll åker på brakförlust mot Gnome. Spotify överras
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s03e09.mdx
+++ b/site/src/episodes/s03e09.mdx
@@ -50,7 +50,7 @@ I veckans avsnitt snackar vi om nya Raspberry Pi, en grym uppdatering till Path 
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s03e10.mdx
+++ b/site/src/episodes/s03e10.mdx
@@ -44,7 +44,7 @@ Vi drar en lättnadens suck över Home Assistant. Nextcloud 19 för COVID-19-tid
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s03e11.mdx
+++ b/site/src/episodes/s03e11.mdx
@@ -38,7 +38,7 @@ Denna veckan samtalar vi om etik kring namngivning i mjukvarubranchen och uppdat
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s03e12.mdx
+++ b/site/src/episodes/s03e12.mdx
@@ -44,7 +44,7 @@ I säsongens sista avsnitt tar vi en titt på nya erbjudanden kring Linux och h�
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s04e01.mdx
+++ b/site/src/episodes/s04e01.mdx
@@ -37,7 +37,7 @@ Vi inleder säsongen med nyheter från bland annat Microsoft, Firefox och GitHub
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s04e02.mdx
+++ b/site/src/episodes/s04e02.mdx
@@ -45,7 +45,7 @@ I veckans avsnitt tar vi en titt på nya LibreOffice, Have I Been Pwned, Nextclo
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s04e03.mdx
+++ b/site/src/episodes/s04e03.mdx
@@ -39,7 +39,7 @@ Vi pratar om Mozilla som säger upp och Epic:s Fortnite som tas ner från Appsto
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/s04e04.mdx
+++ b/site/src/episodes/s04e04.mdx
@@ -38,7 +38,7 @@ Vi diskuterar framtiden för Firefox Send, Rust och MDN efter Mozillas stora oms
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@Kikkusrikkus](https://twitter.com/Kikkusrikkus)

--- a/site/src/episodes/s04e05.mdx
+++ b/site/src/episodes/s04e05.mdx
@@ -32,7 +32,7 @@ I veckans avsnitt snackar vi om nya htop, Firefox och tar en titt på Linux då 
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@Kikkusrikkus](https://twitter.com/Kikkusrikkus)

--- a/site/src/episodes/s04e06.mdx
+++ b/site/src/episodes/s04e06.mdx
@@ -34,7 +34,7 @@ ThinkPads med Linux, i3-gaps, och Alex gör en Nuke 'n Pave. Detta och massa mer
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@Kikkusrikkus](https://twitter.com/Kikkusrikkus)

--- a/site/src/episodes/s04e07.mdx
+++ b/site/src/episodes/s04e07.mdx
@@ -43,7 +43,7 @@ I veckans avsnitt snackas det om ARM-processorer, ett nytt sätt för Mozilla at
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@Kikkusrikkus](https://twitter.com/Kikkusrikkus)

--- a/site/src/episodes/s04e08.mdx
+++ b/site/src/episodes/s04e08.mdx
@@ -29,7 +29,7 @@ Säsongsavslutningen av Trevlig Mjukvara är fullspäckad med nyheter kring KDE 
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@Kikkusrikkus](https://twitter.com/Kikkusrikkus)

--- a/site/src/episodes/s05e01.mdx
+++ b/site/src/episodes/s05e01.mdx
@@ -39,7 +39,7 @@ https://cfenollosa.com/blog/you-may-be-using-mastodon-wrong.html
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@Kikkusrikkus](https://twitter.com/Kikkusrikkus)

--- a/site/src/episodes/s05e02.mdx
+++ b/site/src/episodes/s05e02.mdx
@@ -31,7 +31,7 @@ Denna veckan tittar vi på nya Ubuntu, Edge på Linux och Git. Vi diskuterar äv
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@Kikkusrikkus](https://twitter.com/Kikkusrikkus)

--- a/site/src/episodes/s05e03.mdx
+++ b/site/src/episodes/s05e03.mdx
@@ -38,7 +38,7 @@ I veckans avsnitt sveper vi igenom nya Fedora 33, dreglar över Raspberry Pi 400
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@seb](https://social.gelotte.dev/@seb)

--- a/site/src/episodes/s05e04.mdx
+++ b/site/src/episodes/s05e04.mdx
@@ -46,7 +46,7 @@ Efter 20 år kanske vi får version 3 av Gimp, Tim Berners-Lee försöker att ö
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@seb](https://social.gelotte.dev/@seb)

--- a/site/src/episodes/s05e05.mdx
+++ b/site/src/episodes/s05e05.mdx
@@ -45,7 +45,7 @@ Spionerar Apple på sina användare genom sitt nya operativsystem Big Sur? Högs
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@seb](https://social.gelotte.dev/@seb)

--- a/site/src/episodes/s05e06.mdx
+++ b/site/src/episodes/s05e06.mdx
@@ -43,7 +43,7 @@ Vi djupdyker i Purism och Librem 5. Firefox får prestandaförbättringar. Rust 
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@seb](https://social.gelotte.dev/@seb)

--- a/site/src/episodes/s05e07.mdx
+++ b/site/src/episodes/s05e07.mdx
@@ -47,7 +47,7 @@ Vi kikar in på Home Assistant och pratar om rätten att reparera sina elektroni
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@seb](https://social.gelotte.dev/@seb)

--- a/site/src/episodes/s05e08.mdx
+++ b/site/src/episodes/s05e08.mdx
@@ -38,7 +38,7 @@ I säsongens sista avsnitt ser vi hur både OpenStreetMap och Pine64 växer så 
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@seb](https://social.gelotte.dev/@seb)

--- a/site/src/episodes/s06e01.mdx
+++ b/site/src/episodes/s06e01.mdx
@@ -46,7 +46,7 @@ Vi sparkar igång säsongen med chattappen som rekommenderas av Edward Snowden o
 - YouTube: [Trevlig Mjukvara](https://www.youtube.com/channel/UCRVmpkj-XM6UhUCjGiL3hhQ)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Matrix: [#TrevligMjukvara](https://matrix.to/#/%23TrevligMjukvara:matrix.org)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)

--- a/site/src/episodes/s06e02.mdx
+++ b/site/src/episodes/s06e02.mdx
@@ -43,7 +43,7 @@ Vi dyker ner i lite historia och statistik kring Fediverse. Ubuntu satsar på Wa
 - YouTube: [Trevlig Mjukvara](https://www.youtube.com/channel/UCRVmpkj-XM6UhUCjGiL3hhQ)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Matrix: [#TrevligMjukvara](https://matrix.to/#/%23TrevligMjukvara:matrix.org)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)

--- a/site/src/episodes/s06e03.mdx
+++ b/site/src/episodes/s06e03.mdx
@@ -56,7 +56,7 @@ Chrome vill ta över datasamlandet, Pine64 uppdaterar och VLC fyller 20 år. Vi 
 - YouTube: [Trevlig Mjukvara](https://www.youtube.com/channel/UCRVmpkj-XM6UhUCjGiL3hhQ)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Matrix: [#TrevligMjukvara](https://matrix.to/#/%23TrevligMjukvara:matrix.org)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)

--- a/site/src/episodes/s06e04.mdx
+++ b/site/src/episodes/s06e04.mdx
@@ -60,7 +60,7 @@ Vi synar Open Web Docs och tittar närmare på framtiden för MDN. Terraria avbr
 - YouTube: [Trevlig Mjukvara](https://www.youtube.com/channel/UCRVmpkj-XM6UhUCjGiL3hhQ)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Matrix: [#TrevligMjukvara](https://matrix.to/#/%23TrevligMjukvara:matrix.org)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)

--- a/site/src/episodes/s06e05.mdx
+++ b/site/src/episodes/s06e05.mdx
@@ -50,7 +50,7 @@ Linux körs på Mars och kanske till och med på Googles nya Fuschia OS. Lastpas
 - YouTube: [Trevlig Mjukvara](https://www.youtube.com/channel/UCRVmpkj-XM6UhUCjGiL3hhQ)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Matrix: [#TrevligMjukvara](https://matrix.to/#/%23TrevligMjukvara:matrix.org)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)

--- a/site/src/episodes/s06e06.mdx
+++ b/site/src/episodes/s06e06.mdx
@@ -48,7 +48,7 @@ Vi kikar på det senaste från Nextcloud och får lite härlig statistik från I
 - YouTube: [Trevlig Mjukvara](https://www.youtube.com/channel/UCRVmpkj-XM6UhUCjGiL3hhQ)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Matrix: [#TrevligMjukvara](https://matrix.to/#/%23TrevligMjukvara:matrix.org)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)

--- a/site/src/episodes/s06e07.mdx
+++ b/site/src/episodes/s06e07.mdx
@@ -46,7 +46,7 @@ I säsongsavslutningen fryser Torvalds till mitt i en merge, Flutter infiltrerar
 - YouTube: [Trevlig Mjukvara](https://www.youtube.com/channel/UCRVmpkj-XM6UhUCjGiL3hhQ)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Matrix: [#TrevligMjukvara](https://matrix.to/#/%23TrevligMjukvara:matrix.org)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)

--- a/site/src/episodes/s07e01.mdx
+++ b/site/src/episodes/s07e01.mdx
@@ -48,7 +48,7 @@ Vi lyssnar in på kommandobryggan när Linux flyger på Mars och spekulerar krin
 - YouTube: [Trevlig Mjukvara](https://www.youtube.com/channel/UCRVmpkj-XM6UhUCjGiL3hhQ)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Matrix: [#TrevligMjukvara](https://matrix.to/#/%23TrevligMjukvara:matrix.org)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)

--- a/site/src/episodes/s07e02.mdx
+++ b/site/src/episodes/s07e02.mdx
@@ -47,7 +47,7 @@ Rykande färska versioner av Fedora och Ubuntu. Ett universitet gör bort sig re
 - YouTube: [Trevlig Mjukvara](https://www.youtube.com/channel/UCRVmpkj-XM6UhUCjGiL3hhQ)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Matrix: [#TrevligMjukvara](https://matrix.to/#/%23TrevligMjukvara:matrix.org)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)

--- a/site/src/episodes/s07e03.mdx
+++ b/site/src/episodes/s07e03.mdx
@@ -46,7 +46,7 @@ Signal står på sig, Audacity kikar in i framtiden, Alex snubblar på tangentbo
 - YouTube: [Trevlig Mjukvara](https://www.youtube.com/channel/UCRVmpkj-XM6UhUCjGiL3hhQ)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Matrix: [#TrevligMjukvara](https://matrix.to/#/%23TrevligMjukvara:matrix.org)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)

--- a/site/src/episodes/s07e04.mdx
+++ b/site/src/episodes/s07e04.mdx
@@ -29,7 +29,7 @@ I denna specialare intervjuar vi Jan Ainali, Codebase Steward på Foundation for
 - YouTube: [Trevlig Mjukvara](https://www.youtube.com/channel/UCRVmpkj-XM6UhUCjGiL3hhQ)
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - Matrix: [#TrevligMjukvara](https://matrix.to/#/%23TrevligMjukvara:matrix.org)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)

--- a/site/src/episodes/sommar2020.mdx
+++ b/site/src/episodes/sommar2020.mdx
@@ -55,7 +55,7 @@ I denna sommarspecial snackar vi om hur Trevlig Mjukvara produceras, vad som har
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 
 ## Tack till

--- a/site/src/episodes/vinter2020.mdx
+++ b/site/src/episodes/vinter2020.mdx
@@ -61,7 +61,7 @@ Notera: 32.1% okänd user agent
 - Mail: kontakt@trevligmjukvara.se
 - Twitter: [@trevligmjukvara](https://twitter.com/trevligmjukvara)
 - Telegram: [Trevlig Mjukvara](https://t.me/trevligmjukvara)
-- Mastodon: [@trevligmjukvara](https://mastodon.linuxkompis.se/@trevligmjukvara)
+- Mastodon: [@trevligmjukvara](https://fikaverse.club/@trevligmjukvara)
 - GitHub: [Trevlig Mjukvara](https://github.com/trevligmjukvara)
 - Alex: [@_alexander_](https://mastodon.online/@_alexander_)
 - Seb: [@seb](https://social.gelotte.dev/@seb)


### PR DESCRIPTION
Simply replaces all mastodon.linuxkompis.se-links with fikaverse.club.